### PR TITLE
Add "Documentation" type to the search-indexer

### DIFF
--- a/_plugins/search-indexer.rb
+++ b/_plugins/search-indexer.rb
@@ -61,7 +61,8 @@ module Jekyll::ContentIndexer
       url: url,
       title: page.data["title"],
       content: content,
-      collection: collection
+      collection: collection,
+      type: "Documentation"
     }
 
     @data.push(data)


### PR DESCRIPTION
Adding this as a hardcoded string so we can use a common lambda for docsite and the website (which has multiple types).